### PR TITLE
Remove stabilized feature flags and new panic_abort

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,9 @@
 [[package]]
+name = "panic-abort"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "r0"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7,8 +12,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "rust-picosoc"
 version = "0.1.0"
 dependencies = [
+ "panic-abort 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "r0 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
+"checksum panic-abort 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2c14a66511ed17b6a8b4256b868d7fd207836d891db15eea5195dbcaf87e630f"
 "checksum r0 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2a38df5b15c8d5c7e8654189744d8e396bddc18ad48041a500ce52d6948941f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 name = "rust-picosoc"
 version = "0.1.0"
 authors = ["David Craven <david@craven.ch>"]
+edition = "2018"
 
 [dependencies]
 r0 = "0.2.2"
+panic-abort = "0.3.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
-#![feature(extern_prelude)]
 #![feature(global_asm)]
-#![feature(panic_implementation)]
 #![no_main]
 #![no_std]
 
 const LED_ADDRESS: u32 = 0x0300_0000;
+
+use panic_abort;
 
 // The reset handler
 #[no_mangle]
@@ -35,11 +35,6 @@ extern "C" {
     static _sidata: u32;
 }
 
-#[panic_implementation]
-#[no_mangle]
-pub fn panic_fmt(_info: &core::panic::PanicInfo) -> ! {
-    loop {}
-}
 
 // Make sure there is an abort when linking
 #[cfg(target_arch = "riscv32")]


### PR DESCRIPTION
Adds 2018 edition option.
Removes feature tags extern_prelude, panic_implementation and use panic-abort crate.

However, panic-abort generates a warning about unused import. But if the use statement is removed, build fails.

Signed-off-by: Aurabindo Jayamohanan <mail@aurabindo.in>